### PR TITLE
Add SQL-based internal wallet implementation

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -287,7 +287,7 @@ void update_thread_func()
             }
 
             // Claim the coin with our wallet
-            if (!g_wallet->Insert(soln.webcash)) {
+            if (!g_wallet->Insert(soln.webcash, true)) {
                 // Save the successfully submitted webcash to the log, since we
                 // were unable to add it to the wallet.
                 std::ofstream webcash_log(webcash_log_filename, std::ofstream::app);

--- a/wallet.h
+++ b/wallet.h
@@ -48,11 +48,13 @@ protected:
     boost::interprocess::file_lock m_db_lock;
     sqlite3* m_db;
 
+    void UpgradeDatabase();
+
 public:
     Wallet(const boost::filesystem::path& path);
     ~Wallet();
 
-    bool Insert(const SecretWebcash& sk);
+    bool Insert(const SecretWebcash& sk, bool mine);
 };
 
 #endif // WALLET_H


### PR DESCRIPTION
This PR is still a work in progress. When finished it will extend the `wallet.h` stubs to actually implement a sqlite-backed wallet so that webminer will be able to store generated webcash directly.

There will also be a `webwallet` binary which allows interfacing with this wallet to generate payment codes, receive webcash, import from or export to JSON wallets, etc.