### PR TITLE
Add support for fractional amounts

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -154,6 +154,18 @@ cc_library(
     ]
 )
 
+cc_test(
+    name = "wallet_tests",
+    size = "small",
+    srcs = [
+        "test/wallet.cc",
+    ],
+    deps = [
+        "@com_google_googletest//:gtest_main",
+        ":wallet",
+    ]
+)
+
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 
 cc_binary(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,6 +32,14 @@ git_repository(
     shallow_since = "1641854268 +0000",
 )
 
+# googletest source code repository
+git_repository(
+    name = "com_google_googletest",
+    remote = "https://github.com/google/googletest",
+    commit = "e2239ee6043f73722e7aa812a459f54a28552929",
+    shallow_since = "1623433346 -0700",
+)
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(

--- a/main.cc
+++ b/main.cc
@@ -39,9 +39,9 @@
 
 struct ProtocolSettings {
     // The amount the miner is allowed to claim.
-    int64_t mining_amount;
+    Amount mining_amount;
     // The amount which is surrendered to the server operator.
-    int64_t subsidy_amount;
+    Amount subsidy_amount;
     // The ratio of initial issuance distributed to expected amount.
     float ratio;
     // The number of leading bits which must be zero for a work candidate to be
@@ -92,20 +92,22 @@ bool get_protocol_settings(ProtocolSettings& settings)
         std::cerr << "Error: expected real number for 'ratio' field of ProtocolSettings response, got '" << ratio.write() << "' instead." << std::endl;
         return false;
     }
-    const UniValue& mining_amount = o["mining_amount"];
-    if (!mining_amount.isNum()) {
-        std::cerr << "Error: expected integer for 'mining_amount' field of ProtocolSettings response, got '" << mining_amount.write() << "' instead." << std::endl;
+    const std::string mining_amount_str = o["mining_amount"].write();
+    Amount mining_amount = -1;
+    if (!mining_amount.parse(mining_amount_str) || mining_amount < 0) {
+        std::cerr << "Error: expected fractional-precision numeric value for 'mining_amount' field of ProtocolSettings response, got '" << mining_amount_str << "' instead." << std::endl;
         return false;
     }
-    const UniValue& subsidy_amount = o["mining_subsidy_amount"];
-    if (!subsidy_amount.isNum()) {
-        std::cerr << "Error: expected integer for 'subsidy_amount' field of ProtocolSettings response, got '" << subsidy_amount.write() << "' instead." << std::endl;
+    const std::string subsidy_amount_str = o["mining_subsidy_amount"].write();
+    Amount subsidy_amount = -1;
+    if (!subsidy_amount.parse(subsidy_amount_str) || subsidy_amount < 0) {
+        std::cerr << "Error: expected fractional-precision numeric value for 'subsidy_amount' field of ProtocolSettings response, got '" << subsidy_amount_str << "' instead." << std::endl;
         return false;
     }
     settings.difficulty = difficulty.get_int();
     settings.ratio = ratio.get_real();
-    settings.mining_amount = mining_amount.get_int64();
-    settings.subsidy_amount = subsidy_amount.get_int64();
+    settings.mining_amount = mining_amount;
+    settings.subsidy_amount = subsidy_amount;
     return true;
 }
 
@@ -205,8 +207,8 @@ std::mutex g_state_mutex;
 std::unique_ptr<Wallet> g_wallet;
 std::deque<Solution> g_solutions;
 std::atomic<int> g_difficulty{16};
-std::atomic<int64_t> g_mining_amount{20000};
-std::atomic<int64_t> g_subsidy_amount{1000};
+std::atomic<Amount> g_mining_amount{20000};
+std::atomic<Amount> g_subsidy_amount{1000};
 std::atomic<int64_t> g_attempts{0};
 absl::Time g_last_rng_update{absl::UnixEpoch()};
 absl::Time g_next_rng_update{absl::UnixEpoch()};

--- a/main.cc
+++ b/main.cc
@@ -66,6 +66,15 @@ std::optional<std::string> get_terms_of_service()
     return r->body;
 }
 
+static std::string amount_to_string(const UniValue& val)
+{
+    if (val.isStr()) {
+        return val.get_str();
+    } else {
+        return val.write();
+    }
+}
+
 bool get_protocol_settings(ProtocolSettings& settings)
 {
     httplib::Client cli("https://webcash.tech");
@@ -92,13 +101,13 @@ bool get_protocol_settings(ProtocolSettings& settings)
         std::cerr << "Error: expected real number for 'ratio' field of ProtocolSettings response, got '" << ratio.write() << "' instead." << std::endl;
         return false;
     }
-    const std::string mining_amount_str = o["mining_amount"].write();
+    const std::string mining_amount_str = amount_to_string(o["mining_amount"]);
     Amount mining_amount = -1;
     if (!mining_amount.parse(mining_amount_str) || mining_amount < 0) {
         std::cerr << "Error: expected fractional-precision numeric value for 'mining_amount' field of ProtocolSettings response, got '" << mining_amount_str << "' instead." << std::endl;
         return false;
     }
-    const std::string subsidy_amount_str = o["mining_subsidy_amount"].write();
+    const std::string subsidy_amount_str = amount_to_string(o["mining_subsidy_amount"]);
     Amount subsidy_amount = -1;
     if (!subsidy_amount.parse(subsidy_amount_str) || subsidy_amount < 0) {
         std::cerr << "Error: expected fractional-precision numeric value for 'subsidy_amount' field of ProtocolSettings response, got '" << subsidy_amount_str << "' instead." << std::endl;

--- a/test/wallet.cc
+++ b/test/wallet.cc
@@ -1,0 +1,50 @@
+// Copyright (c) 2022 Mark Friedenbach
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <gtest/gtest.h>
+
+#include "wallet.h"
+
+TEST(amount, parase) {
+    {
+        Amount amt;
+        EXPECT_TRUE(amt.parse("0.1"));
+        EXPECT_EQ(amt.i64, 10000000);
+    }
+    {
+        Amount amt;
+        EXPECT_TRUE(amt.parse("0.00000001"));
+        EXPECT_EQ(amt.i64, 1);
+        EXPECT_FALSE(amt.parse("0.000000001"));
+    }
+    {
+        Amount amt;
+        EXPECT_TRUE(amt.parse("30"));
+        EXPECT_EQ(amt.i64, 3000000000);
+    }
+    {
+        Amount amt;
+        EXPECT_TRUE(amt.parse("30.0"));
+        EXPECT_EQ(amt.i64, 3000000000);
+    }
+}
+
+TEST(amount, to_string) {
+    using std::to_string;
+    EXPECT_EQ(to_string(Amount(3)), "0.00000003");
+    EXPECT_EQ(to_string(Amount(30)), "0.0000003");
+    EXPECT_EQ(to_string(Amount(300)), "0.000003");
+    EXPECT_EQ(to_string(Amount(3000)), "0.00003");
+    EXPECT_EQ(to_string(Amount(30000)), "0.0003");
+    EXPECT_EQ(to_string(Amount(300000)), "0.003");
+    EXPECT_EQ(to_string(Amount(3000000)), "0.03");
+    EXPECT_EQ(to_string(Amount(30000000)), "0.3");
+    EXPECT_EQ(to_string(Amount(300000000)), "3");
+    EXPECT_EQ(to_string(Amount(3000000000)), "30");
+    EXPECT_EQ(to_string(Amount(3000000300)), "30.000003");
+}
+
+// End of File

--- a/test/wallet.cc
+++ b/test/wallet.cc
@@ -16,9 +16,20 @@ TEST(amount, parase) {
     }
     {
         Amount amt;
+        EXPECT_TRUE(amt.parse("\"0.1\""));
+        EXPECT_EQ(amt.i64, 10000000);
+    }
+    {
+        Amount amt;
         EXPECT_TRUE(amt.parse("0.00000001"));
         EXPECT_EQ(amt.i64, 1);
         EXPECT_FALSE(amt.parse("0.000000001"));
+    }
+    {
+        Amount amt;
+        EXPECT_TRUE(amt.parse("\"0.00000001\""));
+        EXPECT_EQ(amt.i64, 1);
+        EXPECT_FALSE(amt.parse("\"0.000000001\""));
     }
     {
         Amount amt;
@@ -27,8 +38,21 @@ TEST(amount, parase) {
     }
     {
         Amount amt;
+        EXPECT_TRUE(amt.parse("\"30\""));
+        EXPECT_EQ(amt.i64, 3000000000);
+    }
+    {
+        Amount amt;
         EXPECT_TRUE(amt.parse("30.0"));
         EXPECT_EQ(amt.i64, 3000000000);
+    }
+    {
+        Amount amt;
+        EXPECT_TRUE(amt.parse("\"30.0\""));
+        EXPECT_EQ(amt.i64, 3000000000);
+        EXPECT_FALSE(amt.parse("\"\"30.0\""));
+        EXPECT_FALSE(amt.parse("\"\"30.0\"\""));
+        EXPECT_FALSE(amt.parse("\"\"30\".0\""));
     }
 }
 

--- a/wallet.cc
+++ b/wallet.cc
@@ -44,9 +44,8 @@ bool Amount::parse(const absl::string_view& str) {
     auto pos = str.begin();
     absl::int128 i = 0;
 
-    bool negative = false;
-    if (*pos == '-') {
-        negative = true;
+    bool negative = (*pos == '-');
+    if (negative) {
         ++pos;
         // A single minus sign is not a valid encoding.
         if (pos == str.end()) {

--- a/wallet.cc
+++ b/wallet.cc
@@ -27,12 +27,119 @@
 
 #include "sqlite3.h"
 
-static std::string webcash_string(int64_t amount, const absl::string_view& type, const uint256& hash)
-{
-    if (amount < 0) {
-        amount = 0;
+// Requires an input that is a fractional-precision decimal with no more than 8
+// digits past the decimal point, with a leading minus sign if the value is
+// negative.  Extremely ficky parser that only values that could be output by
+// to_string(const &Amount) defined below.
+bool Amount::parse(const absl::string_view& str) {
+    // Sanity: no empty strings allowed.
+    if (str.empty()) {
+        return false;
     }
-    return absl::StrCat("e", std::to_string(amount), ":", type, ":", absl::BytesToHexString(absl::string_view((const char*)hash.data(), hash.size())));
+    // Sanity: no embedded NUL characters allowed.
+    if (str.size() != strnlen(str.data(), str.size())) {
+        return false;
+    }
+
+    auto pos = str.begin();
+    absl::int128 i = 0;
+
+    bool negative = false;
+    if (*pos == '-') {
+        negative = true;
+        ++pos;
+        // A single minus sign is not a valid encoding.
+        if (pos == str.end()) {
+            return false;
+        }
+    }
+
+    // A leading zero is required, even for fractional amounts.
+    if (!absl::ascii_isdigit(*pos)) {
+        return false;
+    }
+    // But in that case the next character must be a decimal point.
+    if (pos[0] == '0' && (pos + 1) != str.end() && pos[1] != '.') {
+        return false;
+    }
+
+    for (; pos != str.end() && absl::ascii_isdigit(*pos); ++pos) {
+        i *= 10;
+        i += (*pos - '0');
+        // Overflow check
+        if (i > std::numeric_limits<int64_t>::max()) {
+            return false;
+        }
+    }
+
+    // Fractional digits are optional.
+    int j = 0;
+    if (pos != str.end()) {
+        // Skip past the decimal point.
+        if (*pos != '.') {
+            return false;
+        }
+        ++pos;
+        // If there is a decimal point, there must be at least one digit.
+        if (pos == str.end()) {
+            return false;
+        }
+        // Read up to 8 digits
+        for (; j < 8 && pos != str.end(); ++j, ++pos) {
+            if (!absl::ascii_isdigit(*pos)) {
+                return false;
+            }
+            i *= 10;
+            i += (*pos - '0');
+        }
+        // We must now be at the end of the input
+        if (pos != str.end()) {
+            return false;
+        }
+    }
+    for (; j < 8; ++j) {
+        i *= 10;
+    }
+    // Overflow check
+    if (i > std::numeric_limits<int64_t>::max()) {
+        return false;
+    }
+
+    i64 = static_cast<int64_t>(i);
+    if (negative) {
+        i64 = -i64;
+    }
+    return true;
+}
+
+// Returns the amount formatted as a fixed-precision decimal with 8 fractional
+// digits, as per webcash tradition.  Any terminal zero fractional digits up to
+// and including the decimal place itself are not output.
+//     e.g. 3000000 is rendered as "0.03"
+std::string to_string(const Amount& amt) {
+    using std::to_string;
+    std::lldiv_t div = std::lldiv(std::abs(amt.i64), 100000000LL);
+    std::string res = (amt.i64 < 0) ? "-" : "";
+    res += to_string(div.quot);
+    if (div.rem) {
+        std::string frac = to_string(div.rem);
+        res.push_back('.');
+        res.insert(res.end(), 8 - frac.length(), '0');
+        res += frac;
+        while (res.back() == '0') {
+            res.pop_back();
+        }
+    }
+    return res;
+}
+
+static std::string webcash_string(Amount amount, const absl::string_view& type, const uint256& hash)
+{
+    using std::to_string;
+    if (amount.i64 < 0) {
+        amount.i64 = 0;
+    }
+    return absl::StrCat("e", to_string(amount), ":", type, ":", absl::BytesToHexString(absl::string_view((const char*)hash.data(), hash.size())));
 }
 
 std::string to_string(const SecretWebcash& esk)

--- a/wallet.h
+++ b/wallet.h
@@ -21,16 +21,38 @@
 #include "boost/filesystem.hpp"
 #include "boost/interprocess/sync/file_lock.hpp"
 
+struct Amount {
+    int64_t i64;
+
+    Amount() : i64(0) {}
+    Amount(int64_t _i64) : i64(_i64) {}
+
+    bool parse(const absl::string_view& str);
+};
+
+inline bool operator==(const Amount& lhs, const Amount& rhs) { return lhs.i64 == rhs.i64; }
+inline bool operator!=(const Amount& lhs, const Amount& rhs) { return lhs.i64 != rhs.i64; }
+
+inline bool operator<(const Amount& lhs, const Amount& rhs) { return lhs.i64 < rhs.i64; }
+inline bool operator<=(const Amount& lhs, const Amount& rhs) { return lhs.i64 <= rhs.i64; }
+inline bool operator>=(const Amount& lhs, const Amount& rhs) { return lhs.i64 >= rhs.i64; }
+inline bool operator>(const Amount& lhs, const Amount& rhs) { return lhs.i64 > rhs.i64; }
+
+inline Amount operator-(const Amount& lhs, const Amount& rhs) { return Amount(lhs.i64 - rhs.i64); }
+inline Amount operator+(const Amount& lhs, const Amount& rhs) { return Amount(lhs.i64 + rhs.i64); }
+
+std::string to_string(const Amount& amt);
+
 struct SecretWebcash {
     uint256 sk;
-    int64_t amount;
+    Amount amount;
 };
 
 std::string to_string(const SecretWebcash& esk);
 
 struct PublicWebcash {
     uint256 pk;
-    int64_t amount;
+    Amount amount;
 
     PublicWebcash(const SecretWebcash& esk)
         : amount(esk.amount)


### PR DESCRIPTION
This is an alternative to #5 which adds true support for "fractional" webcash amounts. Internal accounting is still done with 64-bit integers, but interfacing with the server JSON-RPC interface permits either numeric or string values, and properly parses decimals.